### PR TITLE
Proper way to install binstar-build 0.6.0

### DIFF
--- a/content/build/build_queues.html
+++ b/content/build/build_queues.html
@@ -74,7 +74,7 @@ Navigate to your build queue to edit the properties from there you may:
 
 First you must install binstar-build version 0.6.0 or greater
 
-    conda install -c https://conda.binstar.org/binstar binstar-build
+     conda install -c https://conda.binstar.org/binstar/channel/feature:submit-url binstar-build
     
 You only need to do this step once, 
 if you have already done this on another machine point your browser to


### PR DESCRIPTION
I realized that on a fresh install of anaconda on a fresh EC2 Linux instance THIS is the right way to get the 0.6.0 version of binstar.build necessary to run the worker code.