### PR TITLE
change 'github' to 'GitHub'

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -19,7 +19,7 @@ Hosting of freely available software will remain free for individuals and organi
 
 {% call subsection('Contributing to the docs') %}
 
-This documentation is hosted on [github](https://github.com/Anaconda-Server/docs.anaconda.org).
+This documentation is hosted on [GitHub](https://github.com/Anaconda-Server/docs.anaconda.org).
 If you believe there is an omission or error in the documentation,
 please fork the repository and submit a pull request.
 


### PR DESCRIPTION
Tiny capitalization fix, mostly to re-test our deploy scripts and our
readme describing how to use them.