### PR TITLE
modify build docs for anaconda worker register|run|deregister|list

### DIFF
--- a/content/_build/workers.html
+++ b/content/_build/workers.html
@@ -45,21 +45,21 @@ In order to avoid the build-worker waiting on user input for conda commands, con
         conda config --set always_yes true
 {% endsyntax %}
 
-A worker needs to be registered before it can be run.  This command registers a worker for the queue USERNAME/QUEUE and outputs the worker's id and other arguments to a yaml file named ~/.workers/<worker-id>.
+A worker needs to be registered before it can be run.  This command registers a worker for the queue USERNAME/QUEUE and outputs the worker's id and other arguments to a yaml file in ~/.workers/ with the worker's id as the yaml filename.
 
 {% syntax bash %}
-    anaconda build register --queue USERNAME/QUEUE
+    anaconda worker register USERNAME/QUEUE
 {% endsyntax %}
 
 To see other options for registering workers, try
 {% syntax bash %}
-    anaconda build register --help
+    anaconda worker register --help
 {% endsyntax %}
 
-The register step should print out a worker id you can use to run a worker:
+The register step should print out a worker id you can use to run a worker.  This command will start a worker with a ```worker_id```:
 
 {% syntax bash %}
-	anaconda build worker <worker-id-from-register-step>
+	anaconda worker run <worker-id-from-register-step>
 {% endsyntax %}
 
 That's it!  You can now submit a job to your queue and your new build worker will pick it up and build it:
@@ -70,26 +70,21 @@ That's it!  You can now submit a job to your queue and your new build worker wil
 
 **Please note** that you must leave your build worker process running in order to submit builds to it.  You may wish to attach build workers to your queue using a nohup command or similar.
 
-Finally, after killing the anaconda build worker process, it is required to deregister the worker, unless you plan to start the worker again with the same worker id and configuration.  The deregister step can be done by giving the configuration file that was an --output of the anaconda build register step:
+Finally, after killing the anaconda build worker process, it is required to deregister the worker, unless you plan to start the worker again with the same worker id and configuration.  The deregister step can be done with:
 
 {% syntax bash %}
-    anaconda build deregister --worker-id <worker-id-from-register-step>
+    anaconda worker deregister <worker-id-from-register-step>
 {% endsyntax %}
 
-Alternatively, the worker can be deregistered by giving the path to a worker config yaml file:
+If you need to deregister a worker, but have lost the yaml file output from the register step, then check your Anaconda server instance's /settings/build-queue page to remove the worker or list the workers you have registered with this command:
 
 {% syntax bash %}
-    anaconda build deregister --config ~/.workers/<worker-id-from-register-step>
+    anaconda worker list
 {% endsyntax %}
 
-If you need to deregister a worker, but have lost the yaml file output from the register step, then check your Anaconda server instance's /settings/build-queue page to remove the worker or list the workers you have registered by a user on a machine with either of these commands:
-
+Review all help for register, run, deregister, and list with:
 {% syntax bash %}
-    anaconda build register --list
-{% endsyntax %}
-
-{% syntax bash %}
-    anaconda build deregister --list
+    anaconda worker -h
 {% endsyntax %}
 
 {% endcall %}
@@ -137,7 +132,9 @@ The anaconda build cli includes the ability to build in a docker container::
 
 {% syntax bash %}
 	docker pull binstar/linux-64
-	anaconda build docker-worker USERNAME/QUEUENAME --image binstar/linux-64
+    anaconda worker register USERNAME/QUEUENAME
+    # prints worker-id
+	anaconda worker docker_run <worker-id> --image binstar/linux-64
 {% endsyntax %}
 
 {% endcall %}

--- a/content/_build/workers.html
+++ b/content/_build/workers.html
@@ -3,10 +3,10 @@
 {% call section('Build Workers', self) %}
 
 This section contains advanced information on configuring builds on the [anaconda.org](http://anaconda.org)
-platform. If you are not already familiar with the build process, please begin by reading this guide on
+platform. If you are not already familiar with the build process, begin by reading this guide on
 [how to submit your first build](/examples.html#SubmitYourFirstBuild).
 
-Please note that anaconda build defaults to the linux-64 platform, and that [anaconda.org](http://anaconda.org)provides free linux-64 workers.  If you do **not** need to build for other platforms, you can complete package builds using only [anaconda.org](http://anaconda.org). Further, all anaconda.org accounts allow you to
+NOTE: anaconda build defaults to the linux-64 platform, and that [anaconda.org](http://anaconda.org)provides free linux-64 workers.  If you do **not** need to build for other platforms, you can complete package builds using only [anaconda.org](http://anaconda.org). Further, all anaconda.org accounts allow you to
 attach one free worker. If you need more workers or workers on other platforms, you will need to [create a binstar organization](/#CreatingAnOrganization) and [upgrade to a paid plan](/#PaidPlans).
 
 Binstar build workers allow you to run your builds
@@ -30,7 +30,7 @@ To create your queue run:
 {% endsyntax %}
 
 Where `USERNAME` is your [anaconda.org](http://anaconda.org)
-username and `QUEUENAME` is an alphanumeric name of your choice.  For more information about configuring your build queues, please go [here](#/ConfiguringBuildQueues).
+username and `QUEUENAME` is an alphanumeric name of your choice.  For more information about configuring your build queues, go [here](#/ConfiguringBuildQueues).
 
 {% endcall %}
 
@@ -68,7 +68,7 @@ That's it!  You can now submit a job to your queue and your new build worker wil
     anaconda build submit ./my-build --queue USERNAME/QUEUENAME
 {% endsyntax %}
 
-**Please note** that you must leave your build worker process running in order to submit builds to it.  You may wish to attach build workers to your queue using a nohup command or similar.
+NOTE: that you must leave your build worker process running in order to submit builds to it.  You may wish to attach build workers to your queue using a nohup command or similar.
 
 Finally, after killing the anaconda build worker process, it is required to deregister the worker, unless you plan to start the worker again with the same worker id and configuration.  The deregister step can be done with:
 

--- a/content/_examples/install.html
+++ b/content/_examples/install.html
@@ -35,3 +35,16 @@ Or from source
     pip install git+https://github.com/Anaconda-Server/conda-server-build
 
 {% endsection %}
+
+{% section %}
+
+If you are running anaconda-build workers on linux, make sure you have the following prerequisite tools installed: tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, and git.
+
+{% example %}
+
+    yum install -y tar bzip2
+    yum install -y ntp chrpath wget dos2unix gcc gcc-c++
+    yum install -y git
+
+{% endsection %}
+

--- a/content/_examples/install.html
+++ b/content/_examples/install.html
@@ -38,7 +38,7 @@ Or from source
 
 {% section %}
 
-If you are running anaconda-build workers on linux, make sure you have the following prerequisite tools installed: tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, and git.
+If you are running anaconda-build workers on Linux, make sure you have the following prerequisite tools installed: tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, and git.
 
 {% example %}
 


### PR DESCRIPTION
Updates the documentation for the change in anaconda-build worker CLI in this [PR 103](https://github.com/Anaconda-Server/anaconda-build/pull/103).  Specifically:
```bash
anaconda build worker
```
is deprecated in favor of
```bash
anaconda worker [register|run|deregister|list]
```