### PR TITLE
fix links to examples.html

### DIFF
--- a/content/_build/workers.html
+++ b/content/_build/workers.html
@@ -18,7 +18,7 @@ on your own machines. A build worker can run on any
 machine that supports bash (posix) or batch (win32).
 
 To follow along with this tutorial, you will need to
- [install the build cli](/examples.html#HowToInstallTheAnacondaClientCommandLineInterface).
+ [install the build cli](/examples.html#InstallingTheAnacondaClientCommandLineInterface).
 
 
 {% call subsection('Create a Build Queue') %}

--- a/content/_examples/packages.html
+++ b/content/_examples/packages.html
@@ -70,7 +70,7 @@ For example the following repositories are equivalent:
 
 Packages may also be private. This means that a user must explicitly have access to view the package.
 To view and install private packages, you must identify yourself to anaconda.org.
-This is done with [access tokens](examples.html#UsingAnacondaOrgTokens).
+This is done with [access tokens](examples.html#Tokens).
 Once you have generated a token (`<TOKEN>`), you may prefix any repository url with `/t/<TOKEN>`
 
 Note: this is just an example. You will not see any extra private packages in the conda **user namespace**.

--- a/content/faq.html
+++ b/content/faq.html
@@ -195,7 +195,7 @@ For example, to install [this package](https://anaconda.org/pypi/lxml):
 pip install -i https://pypi.anaconda.org/pypi/simple lxml
 ```
 
-You may read more about installing [conda](/examples.html#HowToInstallACondaPackage) and [PyPI](/examples.html#InstallingAPypiPackage) packages.
+You may read more about installing [conda](/examples.html#InstallingCondaPackages) and [PyPI](/examples.html#InstallingPypiPackages) packages.
 
 {% endcall %}
 

--- a/content/index.html
+++ b/content/index.html
@@ -37,7 +37,7 @@ We welcome your [feedback and suggestions](mailto:support@anaconda.org).
   {% call subsection('Getting started') %}
 
 If you want to [author packages](examples.html#CondaPackages) or
-[access private packages](examples.html#UsingAnacondaOrgTokens) you will first need to
+[access private packages](examples.html#Tokens) you will first need to
 [create an account](https://anaconda.org/account/register) on
 [anaconda.org](https://anaconda.org).
 


### PR DESCRIPTION
fix links to examples.html that were broken by the title changes