### PR TITLE
fix conda package link

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -110,7 +110,7 @@ We welcome your [feedback and suggestions](mailto:support@anaconda.org).
       anaconda login
       anaconda upload /your/path/conda-package.tar.bz2
 
-  For detailed information, see the [building packages](examples.html#BuildsInAnacondaOrg) section. 
+  For detailed information, see the [Conda packages](examples.html#CondaPackages) section. 
 
   {% endcall %}
 


### PR DESCRIPTION
Just after the last commit, realized that the link should indeed go
to the Conda packages section rather than the anaconda-build section.
We just need to call it "Conda packages" rather than "building packages"
to eliminate the confusion.