### PR TITLE
Change support to new Anaconda Cloud support

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -30,8 +30,6 @@ Hosting of freely available software will always remain free for individuals and
 public packages.  There is a small fee for the hosting of private packages or more than twenty 
 packages. For more information, please see our [plan options](https://anaconda.org/about/pricing).
 
-We welcome your [feedback and suggestions](mailto:support@anaconda.org).
-
   {% endcall %}
 
 {%- endcall -%}
@@ -128,7 +126,7 @@ Anaconda Cloud, requests for new features, and any other comments you may have.
   
   {% call subsection('Support') %}
 
-For support issues, please contact [Anaconda Cloud Support](mailto:support@anaconda.org).
+For support issues, please see [Anaconda Cloud Support](https://www.continuum.io/support).
 
   {% endcall %}
 


### PR DESCRIPTION
All support requests are currently going to Zendesk, whether paid or free. We want to re-route these folks to https://www.continuum.io/support where a new section is being added, "Anaconda Cloud Support."