### PR TITLE
note that conda-build must be installed for anaconda cloud builds

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -72,7 +72,7 @@
 
   1. Create an account on Anaconda Cloud at <a href="https://anaconda.org/">anaconda.org</a>
   2. Install <a href="https://www.continuum.io/downloads">Anaconda</a> or <a href="http://conda.pydata.org/miniconda.html">Miniconda</a>
-  3. Install Anaconda Client and Anaconda Build: `conda install anaconda-client anaconda-build`
+  3. Install conda build, Anaconda Client and Anaconda Build: `conda install conda-build anaconda-client anaconda-build`
   4. Log in to Anaconda Cloud from the command line using Anaconda Client: `anaconda login`
   5. (**Optional**) Create an organization to be able to create new queues, at <a href="https://anaconda.org/new/organization">anaconda.org/new/organization</a>
 


### PR DESCRIPTION
Note that conda-build must be installed as well as anaconda-build
and anaconda-client for builds in Anaconda Cloud.