### PR TITLE
add reference to Chalmers for cross platform background build workers

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -643,6 +643,12 @@ exclude: true
 
   {% endcall %}
 
+  {% call subsection('Running workers in the background')%}
+
+  The [Chalmers process control system](https://github.com/Anaconda-Server/chalmers) can be used to run build workers in the background across all platforms. Please see the readme file in that repository for further information.
+
+  {% endcall %}
+
   {% call subsection('Configuring build queues')%}
   
   By default your build worker will run builds on your `binstar/public` queue. You may change this in two ways:


### PR DESCRIPTION
Explain that the Chalmers program can be used to run build workers
in the background across Windows as well as OS X and Linux. Link to
Chalmers repository with further information.