### PR TITLE
add notes about quiet:True in binstar.yml

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -458,6 +458,23 @@ env:
 
   {% endcall %}
 
+  {% call subsection('quiet') %}
+  The ```quiet``` key in ```.binstar.yml``` can reduce the amount of superfluous printing to the build logs.  For example, if you see installation messages similar to the following ones in your build log, you can redact these messages by using the ```quiet``` key.
+  {% syntax text %}
+
+    Fetching packages ...
+    ncurses-5.9-1.   0% |                              | ETA:  --:--:--   0.00  B/s
+    ncurses-5.9-1.   2% |                               | ETA:  0:00:00  36.09 MB/s
+    ncurses-5.9-1.   4% |#                              | ETA:  0:00:00  54.15 MB/s
+    ncurses-5.9-1.   6% |##                             | ETA:  0:00:00  66.78 MB/s
+    ncurses-5.9-1.   9% |##                             | ETA:  0:00:00  76.02 MB/s
+
+  {% endsyntax %}
+  More specifically, the following usage of ```quiet``` in the ```.binstar.yml``` file will redact from the build log any message that ends with ```\r```:
+  {% syntax yaml %}
+  quiet: True
+  {% endsyntax %}
+  {% endcall %}
   {% call subsection('Build matrix')%}
 
   When you submit one `.binstar.yml` file many sub-builds are launched, one for each combination of the values of the [platform](#Platform), [engine](#Engine) and [env](#Env) tags.


### PR DESCRIPTION
Merge and deploy this PR only after [anaconda-build PR #160](https://github.com/Anaconda-Server/anaconda-build/pull/160) is merged.  This docs PR adds notes about ```quiet:True``` which can be included in the ```.binstar.yml``` file to redact extra logging messages that end in ```\r```.