### PR TITLE
enable --delete-removed on deploy.sh and deploydraft.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ BUCKET="docs.anaconda.org"
 # git tag "$VERSION"
 hyde gen -r -c prod.yaml
 
-s3cmd -c ~/.s3cfg sync --recursive deploy/ s3://"$BUCKET"/
+s3cmd -c ~/.s3cfg sync --recursive --delete-removed deploy/ s3://"$BUCKET"/
 
 # echo "Don't Forget to update the binstar_app Config file! VERSION=$VERSION"
 echo

--- a/scripts/deploydraft.sh
+++ b/scripts/deploydraft.sh
@@ -5,7 +5,7 @@ BUCKET="docs.anaconda.org"
 # git tag "$VERSION"
 hyde gen -r -c draft.yaml
 
-s3cmd -c ~/.s3cfg sync --recursive deploy/ s3://"$BUCKET"/draft/
+s3cmd -c ~/.s3cfg sync --recursive --delete-removed deploy/ s3://"$BUCKET"/draft/
 
 # echo "Don't Forget to update the binstar_app Config file! VERSION=$VERSION"
 echo 


### PR DESCRIPTION
The deployment scripts for the draft version and live version were
using s3cmd sync without --delete-removed, so scraps of prior versions
of the site were still live alongside the current site. This commit
adds the --delete-removed option to those commands.