### PR TITLE
Revert "enable --delete-removed on deploy.sh and deploydraft.sh"

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ BUCKET="docs.anaconda.org"
 # git tag "$VERSION"
 hyde gen -r -c prod.yaml
 
-s3cmd -c ~/.s3cfg sync --recursive --delete-removed deploy/ s3://"$BUCKET"/
+s3cmd -c ~/.s3cfg sync --recursive deploy/ s3://"$BUCKET"/
 
 # echo "Don't Forget to update the binstar_app Config file! VERSION=$VERSION"
 echo

--- a/scripts/deploydraft.sh
+++ b/scripts/deploydraft.sh
@@ -5,7 +5,7 @@ BUCKET="docs.anaconda.org"
 # git tag "$VERSION"
 hyde gen -r -c draft.yaml
 
-s3cmd -c ~/.s3cfg sync --recursive --delete-removed deploy/ s3://"$BUCKET"/draft/
+s3cmd -c ~/.s3cfg sync --recursive deploy/ s3://"$BUCKET"/draft/
 
 # echo "Don't Forget to update the binstar_app Config file! VERSION=$VERSION"
 echo 


### PR DESCRIPTION
Reverts Anaconda-Server/docs.anaconda.org#229 . Turns out the reason the script didn't use --delete-removed is so that deploying the main version doesn't delete the draft. In the future, it's probably best to clean out the cruft once in a while by running the scripts with the --delete-removed option added, but in general, better to run s3cmd sync without that option, and the scripts in the repository should be saved without the option.