### PR TITLE
notes on env becoming envvars in .binstar.yml

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -430,17 +430,17 @@ engine:
 
   {% endcall %}
 
-  {% call subsubsection('env') %}
+  {% call subsubsection('envvars') %}
 
   An export of environment variables for the sub-build:
 
 {% syntax yaml %}
-env:
+envvars:
   - FOO=BAR
   - ANACONDA=GREAT JENKINS=OK
 {% endsyntax %}
 
-  The items in the `env` tag describe the third of the three axes of the [build matrix](#BuildMatrix).
+  The items in the `envvars` tag describe the third of the three axes of the [build matrix](#BuildMatrix).  The sub-build field `envvars` was formerly called `env` and there is backwards compatability for older sub-build configurations using `env`.
 
   {% endcall %}
 


### PR DESCRIPTION
This has some notes on how ```env``` in .binstar.yml is renamed to ```envvars```, but there is backwards compatability.

This docs PR should be merged at the same time as the release of:
 * [anaconda build PR 175](https://github.com/Anaconda-Server/anaconda-build/pull/175)
 * [anaconda server PR 1451](https://github.com/Anaconda-Server/anaconda-server/pull/1451)
