### PR TITLE
mention subversion is also needed on install

### DIFF
--- a/content/using.html
+++ b/content/using.html
@@ -34,9 +34,9 @@
     pip install git+https://github.com/Anaconda-Server/anaconda-client
     pip install git+https://github.com/Anaconda-Server/anaconda-build
 
-  Running anaconda-build workers on Linux requires installing the prerequisite tools tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, and git:
+  Running anaconda-build workers on Linux requires installing the prerequisite tools tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, git, and subversion:
 
-    yum install -y tar bzip2 ntp chrpath wget dos2unix gcc gcc-c++ git
+    yum install -y tar bzip2 ntp chrpath wget dos2unix gcc gcc-c++ git subversion
 
   {% endcall %}
 


### PR DESCRIPTION
This PR adds a note that build workers should have subversion installed as a prerequisite.