### PR TITLE
use double dash with --channel

### DIFF
--- a/content/using.html
+++ b/content/using.html
@@ -91,8 +91,8 @@
    Commands such as ``conda install`` can be used with a channel or used with a 
    channel and a label:
    
-     conda install —channel sean selenium
-     conda install —channel sean/label/dev selenium
+     conda install —-channel sean selenium
+     conda install —-channel sean/label/dev selenium
 
   {% endcall %}
 


### PR DESCRIPTION
We had -channel instead of --channel, which was an error.