### PR TITLE
remove link to create new package with web ui

### DIFF
--- a/content/using.html
+++ b/content/using.html
@@ -240,12 +240,6 @@
 
   {% endcall %}
 
-  {% call subsection('Creating packages')%}
-
-  All packages you author must be created in a user account. To create a package go to [anaconda.org/new](https://anaconda.org/new).
-  
-  {% endcall %}
-
   {% call subsection('Package privacy settings')%}
 
   You will be prompted with two options:


### PR DESCRIPTION
The docs have a link explaining how to create a new package with the
web UI, but this is not currently useful, so remove this and retain
the instructions on uploading locally created packages.