### PR TITLE
Add patch to the list of needed packages

### DIFF
--- a/content/using.html
+++ b/content/using.html
@@ -34,9 +34,9 @@
     pip install git+https://github.com/Anaconda-Server/anaconda-client
     pip install git+https://github.com/Anaconda-Server/anaconda-build
 
-  Running anaconda-build workers on Linux requires installing the prerequisite tools tar, bzip2, ntp, chrpath, wget, dos2unix, gcc, gcc-c++, git, and subversion:
+  Running anaconda-build workers on Linux requires installing the prerequisite tools tar, bzip2, ntp, chrpath, wget, dos2unix, patch, gcc, gcc-c++, git, and subversion:
 
-    yum install -y tar bzip2 ntp chrpath wget dos2unix gcc gcc-c++ git subversion
+    yum install -y tar bzip2 ntp chrpath wget dos2unix patch gcc gcc-c++ git subversion
 
   {% endcall %}
 


### PR DESCRIPTION
Patch is needed in anaconda-build Linux workers as anaconda
does not provide it and conda may require to patch sources.

Apologies if I am mistaken or if this is not the proper way report this issue. 