### PR TITLE
Update docs about upload and download

### DIFF
--- a/content/_cli/anaconda-client.html
+++ b/content/_cli/anaconda-client.html
@@ -36,8 +36,4 @@ The full command reference is shown below.
 {{ json_command_line_method('copy', 'anaconda copy --json-help', 3) }}
 
 {%   endcall  %}
-
-{%   call subsection('Managing Notebooks') %}
-{{ json_command_line_method('notebook', 'anaconda notebook --json-help', 3) }}
-{%   endcall  %}
 </section>

--- a/content/quickstart.html
+++ b/content/quickstart.html
@@ -91,7 +91,7 @@
 
   Upload a [Jupyter notebook](http://jupyter.org/) (formerly IPython notebook) to Anaconda Cloud:
   
-    anaconda notebook upload my-notebook.ipynb
+    anaconda upload my-notebook.ipynb
     
   An HTML version of the notebook will be at:
     
@@ -99,7 +99,7 @@
     
   Anyone can download it:
 
-    anaconda notebook download username/my-notebook
+    anaconda download username/my-notebook
 
 {%- endcall -%}
 

--- a/content/using.html
+++ b/content/using.html
@@ -345,7 +345,7 @@
 
 Upload a [Jupyter notebook](http://jupyter.org/) (formerly IPython notebook) to Anaconda Cloud:
 
-    anaconda notebook upload my-notebook.ipynb
+    anaconda upload my-notebook.ipynb
   
 An HTML version of the notebook will be at:
   
@@ -353,7 +353,7 @@ An HTML version of the notebook will be at:
   
 Anyone can download it:
 
-    anaconda notebook download username/my-notebook
+    anaconda download username/my-notebook
 
 {%- endcall -%}
 


### PR DESCRIPTION
We are deprecating `anaconda notebook`

So in order to upload a notebook you can use: `anaconda upload`

https://github.com/Anaconda-Server/anaconda-client/issues/295
@electronwill 