### PR TITLE
more notes on anaconda build trigger's options

### DIFF
--- a/content/build.html
+++ b/content/build.html
@@ -220,6 +220,14 @@ about:
     anaconda build save -p #userdefined{USERNAME}/conda_build_test https://github.com/#userdefined{GITHUB_USERNAME}/conda_build_test --channel dev
     anaconda build trigger #userdefined{USERNAME}/conda_build_test
 
+  It is also possible to trigger a build on a specific queue, build host, repository branch, and/or distribution.  For information on options, see
+
+    anaconda build trigger --help
+
+  Here is an example of triggering a build on a queue, repository branch, and linux-64 distribution:
+
+    anaconda build trigger #userdefined{USERNAME}/conda_build_test --dist linux-64 --branch master --queue #userdefined{USERNAME}/#userdefined{QUEUENAME}
+
   {% endcall %}
 
   {% call subsection('Continuous Integration: run a build on git push')%}

--- a/content/build.html
+++ b/content/build.html
@@ -224,9 +224,9 @@ about:
 
     anaconda build trigger --help
 
-  Here is an example of triggering a build on a queue, repository branch, and linux-64 distribution:
+  Here is an example of triggering a build on a queue, repository branch, and centos distribution:
 
-    anaconda build trigger #userdefined{USERNAME}/conda_build_test --dist linux-64 --branch master --queue #userdefined{USERNAME}/#userdefined{QUEUENAME}
+    anaconda build trigger #userdefined{USERNAME}/conda_build_test --dist centos --branch master --queue #userdefined{USERNAME}/#userdefined{QUEUENAME}
 
   {% endcall %}
 


### PR DESCRIPTION
Adds notes regarding new options to `anaconda build trigger` that have come with merge of [server PR 1821](https://github.com/Anaconda-Server/anaconda-server/pull/1821) and [build PR 239](https://github.com/Anaconda-Server/anaconda-build/pull/239)
