### PR TITLE
Update per Travis

### DIFF
--- a/content/quickstart.html
+++ b/content/quickstart.html
@@ -39,7 +39,7 @@
 
   EXAMPLE: To download and install a package with conda run:
 
-      conda install -c https://anaconda.org/USERNAME packagename
+        conda install -c username packagename
 
   {% endcall %}
 


### PR DESCRIPTION
Hi all, 

I just saw again today that we are advertising on Anaconda Cloud that to install from a particular user, we have to list the "full" URL. 

conda install -c https://conda.anaconda.org/ijstokes ansible

The recommended way to do this is actually.  

conda install -c ijstokes ansible

Can we change the automatic docstring on the website?