### PR TITLE
Update per Travis

### DIFF
--- a/content/reference.html
+++ b/content/reference.html
@@ -15,7 +15,7 @@
   {% call subsubsection('Download and install a package from Anaconda Cloud') %}
   To install a conda package, in your terminal window run:
 
-    conda install -c https://anaconda.org/USERNAME packagename
+    conda install -c username packagename
 
   {% endcall %}
 


### PR DESCRIPTION
Travis said: Hi all, 

I just saw again today that we are advertising on Anaconda Cloud that to install from a particular user, we have to list the "full" URL. 

conda install -c https://conda.anaconda.org/ijstokes ansible

The recommended way to do this is actually.  

conda install -c ijstokes ansible

Can we change the automatic docstring on the website?